### PR TITLE
Custom color option to draw detection, http-router to requirements

### DIFF
--- a/robothub_sdk/requirements.txt
+++ b/robothub_sdk/requirements.txt
@@ -1,3 +1,4 @@
 depthai
 paho-mqtt
 paho-socket
+http-router

--- a/robothub_sdk/src/robothub_sdk/draw.py
+++ b/robothub_sdk/src/robothub_sdk/draw.py
@@ -31,7 +31,15 @@ def frame_norm(frame: np.ndarray, bbox: List[float]) -> np.ndarray:
     return (np.clip(np.array(bbox), 0, 1) * norm_vals).astype(int)
 
 
-def draw_detection(detection: dai.ImgDetection, frame: np.ndarray):
+def draw_detection(detection: dai.ImgDetection, frame: np.ndarray, color: Optional[Tuple[int]] = None):
+
+    # validate color
+    if color is not None:
+        if len(color) != 3:
+            raise ValueError("Color must be a tuple of 3 unsigned integers representing color in BGR format.")
+    else: 
+        color = _BBOX_COLORS[detection.label]
+
     bbox = frame_norm(frame, [detection.xmin, detection.ymin, detection.xmax, detection.ymax])
     # bbox[::2] += self._crop_offset_x(frame)
     cv2.rectangle(frame, (bbox[0], bbox[1]), (bbox[2], bbox[3]), _BBOX_COLORS[detection.label], 2)


### PR DESCRIPTION
Add custom color option to detections:
`draw_detection(detection, cv_frame, color = (0, 255, 0))`